### PR TITLE
Expanded cell creation

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use serde_json::json;
 use tokio::sync::Mutex;
 
 use std::collections::HashMap;
@@ -94,7 +95,8 @@ impl AppState {
     }
 
     // Return cell_id
-    async fn create_cell(&self, window_id: &str, cell_type: Option<&str>) -> Option<String> {
+    async fn create_cell(&self, window: Window, cell_type: Option<&str>) -> Option<String> {
+        let window_id = window.label();
         debug!("Creating a new cell in window with ID: {}", window_id);
 
         let cell_type = cell_type.unwrap_or("code");
@@ -111,7 +113,8 @@ impl AppState {
     }
 
     // Update a specific cell within the specified notebook
-    async fn update_cell(&self, window_id: &str, cell_id: &str, new_content: &str) -> bool {
+    async fn update_cell(&self, window: Window, cell_id: &str, new_content: &str) -> bool {
+        let window_id = window.label();
         debug!(
             "Updating cell with ID: {} in window with ID: {} with new content: {}",
             cell_id, window_id, new_content
@@ -121,6 +124,13 @@ impl AppState {
         if let Some(notebook) = notebooks.get_mut(window_id) {
             if let Some(cell) = notebook.get_mut_cell(cell_id) {
                 cell.set_source(new_content);
+
+                window.emit(
+                    format!("cell-{}", cell_id).as_str(),
+                    Some(json!({
+                        "source": new_content
+                    }))
+                ).unwrap();
             }
             true
         } else {
@@ -131,8 +141,7 @@ impl AppState {
 
 #[tauri::command]
 async fn create_cell(state: State<'_, AppState>, window: Window, cell_type: &str) -> Result<Option<String>, String> {
-    let window_id = window.label(); // Use the window label as a unique identifier
-    Ok(state.create_cell(window_id, Some(cell_type)).await)
+    Ok(state.create_cell(window, Some(cell_type)).await)
 }
 
 #[tauri::command]
@@ -151,8 +160,7 @@ async fn update_cell(
     cell_id: &str,
     new_content: &str,
 ) -> Result<bool, String> {
-    let window_id = window.label(); // Use the window label as a unique identifier
-    Ok(state.update_cell(window_id, cell_id, new_content).await)
+    Ok(state.update_cell(window, cell_id, new_content).await)
 }
 
 // The main entry point for the Tauri application

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,23 @@
-import Cell from "@/components/Cell";
-
-import { Button} from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { useNotebook } from '@/hooks/useNotebook';
+
+import { MarkdownCell } from "@/components/markdown-cell"
+import { CodeCell } from '@/components/code-cell'
 
 function App() {
   const { cells, createCodeCell, createMarkdownCell } = useNotebook();
   return (
     <div>
-      {cells.map((cellId: string) => (
-          <Cell cellId={cellId} key={cellId}/>
-      ))}
+      {cells.map((cellInfo) => {
+        switch (cellInfo.cellType) {
+          case "code":
+            return <CodeCell cellId={cellInfo.id} key={cellInfo.id} />
+          case "markdown":
+            return <MarkdownCell cellId={cellInfo.id} key={cellInfo.id} />
+          default:
+            return "Unknown cell type"
+        }
+      })}
       <Button onClick={createCodeCell}>New Code Cell</Button>
       <Button onClick={createMarkdownCell}>New Markdown Cell</Button>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,14 @@ import { Button} from "@/components/ui/button";
 import { useNotebook } from '@/hooks/useNotebook';
 
 function App() {
-  const { cells, createCell } = useNotebook();
+  const { cells, createCodeCell, createMarkdownCell } = useNotebook();
   return (
     <div>
       {cells.map((cellId: string) => (
           <Cell cellId={cellId} key={cellId}/>
       ))}
-      <Button onClick={createCell}>New Cell</Button>
+      <Button onClick={createCodeCell}>New Code Cell</Button>
+      <Button onClick={createMarkdownCell}>New Markdown Cell</Button>
     </div>
   );
 }

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -1,9 +1,0 @@
-import {CodeCell} from "@/components/code-cell"
-
-const Cell = ({ cellId }: { cellId: string }) => {
-  // Until we have cell types coming in from the backend, we'll assume this is a code cell
-  return <CodeCell cellId={cellId} />
-
-};
-
-export default Cell;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -6,7 +6,7 @@ import { lightTheme } from "@/codemirror-themes";
 
 import { StateField } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
-import { useCodeCell } from "@/hooks/useCell";
+import { useCell } from "@/hooks/useCell";
 
 import { invoke } from "@tauri-apps/api/tauri";
 
@@ -82,7 +82,7 @@ const baseExtensions = [
 export const Editor = ({ cellId, className, language }: { cellId: string, className?: string, language: string }) => {
   const ref = useRef<HTMLDivElement>(null);
 
-  const { content, updateCell } = useCodeCell(cellId);
+  const { content, updateCell } = useCell(cellId);
 
   // We need to compute a derived extensions state based on the language of the editor
   const extensions = useMemo(() => {

--- a/src/components/markdown-cell.tsx
+++ b/src/components/markdown-cell.tsx
@@ -3,6 +3,8 @@ import { useRemark } from "react-remark";
 
 import { useMarkdownCell } from "@/hooks/useCell";
 
+import { Editor } from "@/components//Editor";
+
 export const MarkdownCell = ({ cellId }: { cellId: string }) => {
   const { content } = useMarkdownCell(cellId);
 
@@ -12,12 +14,20 @@ export const MarkdownCell = ({ cellId }: { cellId: string }) => {
     setMarkdownSource(content);
   }, [content]);
 
+  console.log(content)
+
 
   return (
     <div className="flex items-start">
       <div className="w-14 h-full pt-1 pb-1 m-0">
       {/* placeholder */}
       </div>
+
+      <Editor
+          cellId={cellId}
+          className="mr-2 pt-0 pb-0 text-sm"
+          language="markdown"
+        />
 
       <div className="prose">{reactContent}</div>
     </div>

--- a/src/hooks/useNotebook.ts
+++ b/src/hooks/useNotebook.ts
@@ -1,13 +1,18 @@
 import { useState, useCallback } from 'react';
 import { invoke } from "@tauri-apps/api/tauri";
 
-export function useNotebook() {
-  const [cells, setCells] = useState<string[]>([]);
+type CellInfo = {
+  id: string,
+  cellType: "code" | "markdown"
+}
 
-  async function createCell(cellType: "code" | "markdown") {
+export function useNotebook() {
+  const [cells, setCells] = useState<CellInfo[]>([]);
+
+  const createCell = useCallback(async (cellType: "code" | "markdown") => {
     const id = (await invoke("create_cell", { cellType })) as string;
-    setCells(oldCells => [...oldCells, id]);
-  }
+    setCells(oldCells => [...oldCells, { id, cellType }]);
+  }, []);
 
   const createCodeCell = useCallback(() => createCell("code"), [createCell]);
   const createMarkdownCell = useCallback(() => createCell("markdown"), [createCell]);

--- a/src/hooks/useNotebook.ts
+++ b/src/hooks/useNotebook.ts
@@ -1,15 +1,16 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { invoke } from "@tauri-apps/api/tauri";
 
 export function useNotebook() {
   const [cells, setCells] = useState<string[]>([]);
 
-  async function createCell() {
-    const id = (await invoke("create_cell")) as string;
+  async function createCell(cellType: "code" | "markdown") {
+    const id = (await invoke("create_cell", { cellType })) as string;
     setCells(oldCells => [...oldCells, id]);
   }
 
-  // TODO(kyle): Listen to events from the backend to update the cell list
+  const createCodeCell = useCallback(() => createCell("code"), [createCell]);
+  const createMarkdownCell = useCallback(() => createCell("markdown"), [createCell]);
 
-  return { cells, createCell };
+  return { cells, createCell, createCodeCell, createMarkdownCell};
 }


### PR DESCRIPTION
This accepts updates from the Tauri backend when a cell is updated. It's a little bit circular in appearance for most cases since typically this will:

* Change content in codemirror
* Set local state for `source`
* Submit change over to Tauri
* Recieve update from Tauri
* Set local state for `source` to that which was updated by Tauri

However for Markdown cells this immediately makes the source of truth for the rendered view come from Tauri rather than in the frontend of the app.